### PR TITLE
doc(README.md): fix "add to path" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,5 +186,5 @@ chmod u+x /config/scripts/vyaml
 To add it to the path, run the following command:
 ```bash
 echo 'sudo ln -sf /config/scripts/vyaml /usr/local/bin/vyaml' | sudo tee -a /config/scripts/vyos-postconfig-bootup.script
-sh /config/scripts/vyos-postconfig-bootup.script
+vbash /config/scripts/vyos-postconfig-bootup.script
 ```


### PR DESCRIPTION
VyOS's `vbash` interprets commands starting with `sh` as `show` commands. We need to either give a full path (e.g., `/bin/sh`), or a more explicit command name.

Given that (as far as I'm aware) the VyOS post-run scripts run under `vbash`, I figure that should be a fine choice of shell to use for this.

I think this is still worth fixing, despite the fact that #7 will completely change the way vyaml is installed, because it will lessen friction for people to test and experiment with it.