### PR TITLE
feat: Build both amd64 and arm64 binary

### DIFF
--- a/.github/workflows/alpha.yaml
+++ b/.github/workflows/alpha.yaml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
     tags-ignore:
-      - '**'
+      - "**"
 
 jobs:
   alpha:
@@ -29,8 +29,11 @@ jobs:
       - name: Substitute version
         run: sed -i 's/__version__/${{ steps.sha.outputs.sha_short }}/' vyaml.py
 
-      - name: Build
-        run: pyinstaller -F vyaml.py --hidden-import json
+      - name: Build x86_64
+        run: pyinstaller -F vyaml.py --hidden-import json --target-architecture x86_64 -n vyaml-amd64
+
+      - name: Build arm64
+        run: pyinstaller -F vyaml.py --hidden-import json --target-architecture arm64 -n vyaml-arm64
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ name: release
 on:
   push:
     tags:
-      - '**'
+      - "**"
 
 permissions:
   contents: write
@@ -26,11 +26,16 @@ jobs:
       - name: Substitute version
         run: sed -i 's/__version__/${{ github.ref_name }}/' vyaml.py
 
-      - name: Build
-        run: pyinstaller -F vyaml.py --hidden-import json
+      - name: Build x86_64
+        run: pyinstaller -F vyaml.py --hidden-import json --target-architecture x86_64 -n vyaml-amd64
+
+      - name: Build arm64
+        run: pyinstaller -F vyaml.py --hidden-import json --target-architecture arm64 -n vyaml-arm64
 
       - name: Upload release
         uses: softprops/action-gh-release@v1 # this version is not correct in their docs
         with:
-          files: dist/vyaml
+          files: |
+            dist/vyaml-amd64
+            dist/vyaml-arm64
           generate_release_notes: true


### PR DESCRIPTION
This PR should make it so that both an `amd64` and an `arm64` version get built. This makes it a lot easier for (example) Apple Silicon users to use the tool locally :)