### PR TITLE
fix(GHA): follow dpkg-name standards for .deb file names

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -69,8 +69,8 @@ jobs:
 
       - name: Relocate deb packages
         run: |
-          mv ${{ steps.deb_amd64.outputs.file_name }} dist/vyaml-amd64.deb
-          mv ${{ steps.deb_arm64.outputs.file_name }} dist/vyaml-arm64.deb
+          mv ${{ steps.deb_amd64.outputs.file_name }} dist/vyaml_${{ github.ref_name }}_amd64.deb
+          mv ${{ steps.deb_arm64.outputs.file_name }} dist/vyaml_${{ github.ref_name }}_arm64.deb
 
       - name: Upload release
         uses: softprops/action-gh-release@v1 # this version is not correct in their docs


### PR DESCRIPTION
VyOS build process won't pick up the .deb files unless the names follow the following format: `<package>_<version>_<architecture>.deb` (from `dpkg-name` man page)